### PR TITLE
Fix: GitHub Pages Deployment (404 Error)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,9 +28,10 @@ jobs:
 
       - name: build
         env:
-          BASE_PATH: ${{ github.event.repository.name == 'kevinap29.github.io' && '' || format('/{0}', github.event.repository.name) }}
+          BASE_PATH: ""
         run: |
           npm run build
+          touch build/.nojekyll
 
       # - name: Generate sitemap
       #   run: npm run generate:sitemap


### PR DESCRIPTION
This PR fixes the 'Page Not Found' issue on GitHub Pages:
1. **BASE_PATH**: Set to empty string because the repository 'kevinap29.github.io' is a User Page and must be served from root.
2. **.nojekyll**: Added to prevent Jekyll from ignoring SvelteKit's '_app' directory.
3. **Paths**: Removed deprecated base import in layout server (cleaner code).